### PR TITLE
修复时间超过一轮最大时间后，定时失败的问题

### DIFF
--- a/tw.go
+++ b/tw.go
@@ -104,8 +104,10 @@ func (tw *TimeWheel) handle() {
 	l := tw.slots[tw.currPos]
 
 	for e := l.Front(); e != nil; {
+		curElement := e
 		task := e.Value.(*Task)
-
+		next := e.Next()
+		e = next
 		if task.circle > 0 {
 			task.circle--
 			continue
@@ -113,12 +115,10 @@ func (tw *TimeWheel) handle() {
 
 		go task.fn(task.params)
 
-		next := e.Next()
-		l.Remove(e)
+		l.Remove(curElement)
 		if task.key != nil {
 			delete(tw.keyPosMap, task.key)
 		}
-		e = next
 	}
 
 	tw.currPos = (tw.currPos + 1) % tw.slotNum
@@ -127,7 +127,8 @@ func (tw *TimeWheel) handle() {
 // getPosAndCircle Func: parse duration by interval to get circle and position
 func (tw *TimeWheel) getPosAndCircle(d time.Duration) (pos int, circle int) {
 	circle = int(d.Seconds()) / int(tw.interval.Seconds()) / tw.slotNum
-	pos = tw.currPos + int(tw.interval.Seconds())/int(tw.interval.Seconds())%tw.slotNum
+
+	pos = (tw.currPos + int(d.Seconds())/int(tw.interval.Seconds())) % tw.slotNum
 	return
 }
 

--- a/tw_test.go
+++ b/tw_test.go
@@ -51,3 +51,24 @@ func TestStopTimeWheel(t *testing.T) {
 
 	time.Sleep(time.Duration(5) * time.Second)
 }
+
+func TestBigDelay(t *testing.T) {
+	tw := New(2*time.Second, 2)
+	taskDelay := 7 * time.Second
+	tw.Start()
+	begin := time.Now()
+	name := "ID1"
+	params := map[string]int{"age": 1}
+	fn := func(data interface{}) {
+		fmt.Printf("hello, %v\n", data)
+		cost := int(time.Now().Sub(begin).Seconds())
+		if cost != 8 {
+			t.Fail()
+		}
+		fmt.Println("cso = ", cost)
+	}
+	tw.AddTimer(taskDelay, name, fn, params)
+
+	time.Sleep(time.Duration(20) * time.Second)
+
+}


### PR DESCRIPTION
在原代码中，当设定任务的延迟时间大于时间轮一圈的时间后，任务执行时间错误